### PR TITLE
Fix highlightCategories NPE

### DIFF
--- a/src/main/java/com/evansloan/collectionlog/CollectionLogPlugin.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogPlugin.java
@@ -294,6 +294,12 @@ public class CollectionLogPlugin extends Plugin
 		for (CollectionLogList listType : CollectionLogList.values())
 		{
 			Widget categoryList = client.getWidget(COLLECTION_LOG_GROUP_ID, listType.getListIndex());
+
+			if (categoryList == null)
+			{
+				continue;
+			}
+
 			Widget[] names = categoryList.getDynamicChildren();
 			for (Widget name : names)
 			{


### PR DESCRIPTION
`update()` is called on plugin start, which makes no guarantee that there will be category widgets on screen to be updated. Hence, it is important to null-check the category list widgets.

Ref: evansloan/collection-log#3