### PR TITLE
fix private messages command

### DIFF
--- a/src/main/java/com/evansloan/collectionlog/CollectionLogPlugin.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogPlugin.java
@@ -33,6 +33,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.IndexedSprite;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
+import net.runelite.api.Player;
 import net.runelite.api.ScriptID;
 import net.runelite.api.WorldType;
 import net.runelite.api.events.ChatMessage;
@@ -930,10 +931,17 @@ public class CollectionLogPlugin extends Plugin
 	 */
 	private void collectionLogLookup(ChatMessage chatMessage, String message)
 	{
+		Player localPlayer = client.getLocalPlayer();
+		String username = chatMessage.getName();
+		if (chatMessage.getType().equals(ChatMessageType.PRIVATECHATOUT))
+		{
+			username = localPlayer.getName();
+		}
+
 		CollectionLog collectionLog;
 		try
 		{
-			collectionLog = apiClient.getCollectionLog(sanitize(chatMessage.getName()));
+			collectionLog = apiClient.getCollectionLog(sanitize(username));
 		}
 		catch (IOException e)
 		{


### PR DESCRIPTION
This fixes an issue where private messages would always use the other person's name instead of the sender of the message. The type of message is checked and if it is an outgoing private message the local player name is used instead.