### PR TITLE
Fix incorrect kill count amounts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.evansloan.collectionlog'
-version = '3.0.0'
+version = '3.0.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/evansloan/collectionlog/CollectionLogConfig.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogConfig.java
@@ -10,7 +10,7 @@ import net.runelite.client.config.ConfigSection;
 @ConfigGroup("collectionlog")
 public interface CollectionLogConfig extends Config
 {
-	String PLUGIN_VERSION = "3.0.0";
+	String PLUGIN_VERSION = "3.0.1";
 
 	Color DEFAULT_GREEN = new Color(13, 193, 13);
 	Color DEFAULT_ORANGE = new Color(255, 152, 31);

--- a/src/main/java/com/evansloan/collectionlog/CollectionLogKillCount.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogKillCount.java
@@ -2,6 +2,7 @@ package com.evansloan.collectionlog;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 import net.runelite.client.util.Text;
 
 @Getter
@@ -9,7 +10,8 @@ import net.runelite.client.util.Text;
 public class CollectionLogKillCount
 {
     private final String name;
-    private final int amount;
+	@Setter
+    private int amount;
     private final int sequence;
 
 	public static CollectionLogKillCount fromString(String killCountString, int sequence)

--- a/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
@@ -175,7 +175,12 @@ public class CollectionLogManager
 					}
 				}
 
-				// Run script to get kill counts for current page, pushes 3 (possibly empty) strings onto stack
+				/*
+				 * Run script to get available kill count names. Amounts are set in var2048 which isn't set unless
+				 * pages are manually opened in-game. Override amounts with 0 or previously saved amounts.
+				 *
+				 * https://github.com/Joshua-F/cs2-scripts/blob/master/scripts/%5Bproc,collection_category_count%5D.cs2
+				 */
 				client.runScript(COLLECTION_LOG_KILL_COUNT_SCRIPT_ID, pageStruct.getId());
 				List<String> killCountStrings = new ArrayList<>(
 					Arrays.asList(Arrays.copyOfRange(client.getStringStack(), 0, 3))
@@ -189,6 +194,15 @@ public class CollectionLogManager
 						continue;
 					}
 					CollectionLogKillCount killCount = CollectionLogKillCount.fromString(killCountString, pageKillCounts.size());
+
+					int killCountAmount = 0;
+					if (saveFilePage != null)
+					{
+						CollectionLogKillCount saveFileKc = saveFilePage.getKillCountByName(killCount.getName());
+						killCountAmount = saveFileKc.getAmount();
+					}
+
+					killCount.setAmount(killCountAmount);
 					pageKillCounts.add(killCount);
 				}
 

--- a/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
@@ -199,7 +199,10 @@ public class CollectionLogManager
 					if (saveFilePage != null)
 					{
 						CollectionLogKillCount saveFileKc = saveFilePage.getKillCountByName(killCount.getName());
-						killCountAmount = saveFileKc.getAmount();
+						if (saveFileKc != null)
+						{
+							killCountAmount = saveFileKc.getAmount();
+						}
 					}
 
 					killCount.setAmount(killCountAmount);

--- a/src/main/java/com/evansloan/collectionlog/CollectionLogPage.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogPage.java
@@ -478,4 +478,16 @@ public class CollectionLogPage
 
 		return items.stream().filter(filter).collect(Collectors.toList());
 	}
+
+	public CollectionLogKillCount getKillCountByName(String name)
+	{
+		for (CollectionLogKillCount killCount : getKillCounts())
+		{
+			if (killCount.getName().equals(name))
+			{
+				return killCount;
+			}
+		}
+		return null;
+	}
 }


### PR DESCRIPTION
Closes #31

When initializing kill count amounts on first log open, kill count amount values are pulled from varbit 2048. Varbit 2048 is not updated with the values for each kill count unless the page is manually opened in-game.

Fix: Initialize kill count amounts with 0 or previously saved kill count value.

Other changes:
* Bump version to 3.0.1
* Add helper method to get kill counts by name

