### PR TITLE
feat: remove loading old data format

### DIFF
--- a/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
@@ -255,19 +255,8 @@ public class CollectionLogManager
 			return;
 		}
 
-		boolean isOldFileFormat = directory == COLLECTION_LOG_DIR;
-
 		for (File file : files)
 		{
-			if (file.isDirectory())
-			{
-				if (!isOldFileFormat)
-				{
-					loadCollectionLogFiles(file);
-				}
-				continue;
-			}
-
 			Matcher matcher = COLLECTION_LOG_FILE_PATTERN.matcher(file.getName());
 			if (!matcher.matches())
 			{
@@ -275,19 +264,15 @@ public class CollectionLogManager
 			}
 
 			String fileUsername = matcher.group(1);
-			CollectionLog loadedCollectionLog = jsonUtils.readJsonFile(file.getPath(), CollectionLog.class, new CollectionLogDeserializer(isOldFileFormat));
+			CollectionLog loadedCollectionLog = jsonUtils.readJsonFile(file.getPath(), CollectionLog.class, new CollectionLogDeserializer());
 			loadedCollectionLogs.put(fileUsername, loadedCollectionLog);
 		}
 	}
 
 	public void loadCollectionLogFiles()
 	{
-		// Old save files
-		loadCollectionLogFiles(COLLECTION_LOG_DIR);
-		// New save files
 		loadCollectionLogFiles(COLLECTION_LOG_SAVE_DATA_DIR);
 	}
-
 
 	public UserSettings loadUserSettingsFile()
 	{

--- a/src/main/java/com/evansloan/collectionlog/util/CollectionLogDeserializer.java
+++ b/src/main/java/com/evansloan/collectionlog/util/CollectionLogDeserializer.java
@@ -38,32 +38,15 @@ public class CollectionLogDeserializer implements JsonDeserializer<CollectionLog
 		}
 	};
 
-	private boolean isOldFileFormat = false;
-
 	public CollectionLogDeserializer()
 	{
 		super();
-	}
-
-	public CollectionLogDeserializer(boolean isOldSaveFormat)
-	{
-		super();
-		this.isOldFileFormat = isOldSaveFormat;
 	}
 
     @Override
     public CollectionLog deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext context) throws JsonParseException
     {
         JsonObject jsonObjectLog = jsonElement.getAsJsonObject();
-        if (isOldFileFormat)
-        {
-            // Old file format uses snake cased keys
-            keyMap.put(COLLECTION_LOG_KILL_COUNTS_KEY, "kill_count");
-            keyMap.put(COLLECTION_LOG_TOTAL_OBTAINED_KEY, "total_obtained");
-            keyMap.put(COLLECTION_LOG_TOTAL_ITEMS_KEY, "total_items");
-            keyMap.put(COLLECTION_LOG_UNIQUE_OBTAINED_KEY, "unique_obtained");
-            keyMap.put(COLLECTION_LOG_UNIQUE_ITEMS_KEY, "unique_items");
-        }
 
         JsonObject jsonObjectTabs = jsonObjectLog.get(COLLECTION_LOG_TABS_KEY).getAsJsonObject();
 
@@ -92,15 +75,7 @@ public class CollectionLogDeserializer implements JsonDeserializer<CollectionLog
                     for (JsonElement killCount : pageKillCounts.getAsJsonArray())
                     {
                         CollectionLogKillCount newKillCount;
-                        if (isOldFileFormat)
-                        {
-                            String killCountString = killCount.getAsString();
-							newKillCount = CollectionLogKillCount.fromString(killCountString, newKillCounts.size());
-                        }
-                        else
-                        {
-                            newKillCount = context.deserialize(killCount, CollectionLogKillCount.class);
-                        }
+                        newKillCount = context.deserialize(killCount, CollectionLogKillCount.class);
                         newKillCounts.add(newKillCount);
                     }
                 }


### PR DESCRIPTION
Removes loading of old data format. Only the new data format from the `data` folder will be loaded. Hopefully fixes the various reported issues about the asterisk (*) returning after each time the client is closed and opened.

Tested what happens if that file is not present (yet), it will correctly create a new empty data file.