### PR TITLE
hotfix: correctly loading collection log files again

### DIFF
--- a/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
@@ -286,9 +286,21 @@ public class CollectionLogManager
 		}
 	}
 
-	public void loadCollectionLogFiles()
-	{
-		loadCollectionLogFiles(COLLECTION_LOG_SAVE_DATA_DIR);
+	public void loadCollectionLogFiles() {
+		if (!COLLECTION_LOG_SAVE_DATA_DIR.exists() || !COLLECTION_LOG_SAVE_DATA_DIR.isDirectory()) {
+			log.error("Directory: \"" + COLLECTION_LOG_DIR.getPath() + "\" does not exist");
+			return;
+		}
+
+		File[] userDirectories = COLLECTION_LOG_SAVE_DATA_DIR.listFiles();
+		if (userDirectories == null) {
+			log.warn("No collection logs have been found");
+			return;
+		}
+
+		for (File userDirectory : userDirectories) {
+			loadCollectionLogFiles(userDirectory);
+		}
 	}
 
 	public UserSettings loadUserSettingsFile()


### PR DESCRIPTION
Due to receiving more reports about the collection log not correctly loading and users having to manually click through each collection log to update I investigated what the newly introduced bug was.

After my last PR #33 I removed the old format loading, but was a bit too ignorant for regressing testing it. The new saves were not loaded, as only the `/data/` directory would be iterated and the `loadCollectionLogFiles` function would check if the directory contains files. As the `/data/` directory only contains directories of the user accounts, it would return, practically doing nothing.

Reworked the `loadCollectionLogFiles` function to invoke the `loadCollectionLogFiles` overload for each user account directory.