### PR TITLE
Fix null pointer exception in save method

### DIFF
--- a/src/main/java/com/evansloan/collectionlog/CollectionLogPlugin.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogPlugin.java
@@ -164,9 +164,10 @@ public class CollectionLogPlugin extends Plugin
 			unsetOldConfigs();
 		}
 
+		initPanel();
 		if (config.showCollectionLogSidePanel())
 		{
-			initPanel();
+			clientToolbar.addNavigation(navigationButton);
 		}
 
 		// Load all save files up front on executor thread to mitigate lag on log open
@@ -199,8 +200,6 @@ public class CollectionLogPlugin extends Plugin
 				.priority(10)
 				.build();
 		}
-
-		clientToolbar.addNavigation(navigationButton);
 	}
 
 	private void destroyPanel()
@@ -219,20 +218,14 @@ public class CollectionLogPlugin extends Plugin
 
 		if (configChanged.getKey().equals(CONFIG_SHOW_PANEL))
 		{
+			clientToolbar.removeNavigation(navigationButton);
 			if (config.showCollectionLogSidePanel())
 			{
-				initPanel();
-			}
-			else
-			{
-				destroyPanel();
+				clientToolbar.addNavigation(navigationButton);
 			}
 		}
 
-		if (collectionLogPanel != null)
-		{
-			collectionLogPanel.onConfigChanged(configChanged);
-		}
+		collectionLogPanel.onConfigChanged(configChanged);
 	}
 
 	@Subscribe
@@ -246,11 +239,7 @@ public class CollectionLogPlugin extends Plugin
 		if (gameStateChanged.getGameState() == GameState.LOGGED_IN)
 		{
 			isUserLoggedIn = true;
-
-			if (collectionLogPanel != null)
-			{
-				collectionLogPanel.setStatus("", false, true);
-			}
+			collectionLogPanel.setStatus("", false, true);
 
 			unsetOldConfigs();
 		}
@@ -262,11 +251,7 @@ public class CollectionLogPlugin extends Plugin
 			collectionLogManager.reset();
 			resetFlags();
 		}
-
-		if (collectionLogPanel != null)
-		{
-			collectionLogPanel.onGameStateChanged(gameStateChanged);
-		}
+		collectionLogPanel.onGameStateChanged(gameStateChanged);
 	}
 
 	@Subscribe


### PR DESCRIPTION
Steps to reproduce:

- log in to the game
- toggle the side panel off in the config
- log off

This change will add and remove the navigation button instead of destroying and recreating the side panel so that the panel can always be used. It only turns to null on the shutdown so I removed some null checks too.

```
java.lang.NullPointerException: Cannot invoke "com.evansloan.collectionlog.CollectionLogPanel.setStatus(String, boolean, boolean)" because "this.collectionLogPanel" is null
	at com.evansloan.collectionlog.CollectionLogPlugin.saveCollectionLogData(CollectionLogPlugin.java:520)
	at com.evansloan.collectionlog.CollectionLogPlugin.onGameStateChanged(CollectionLogPlugin.java:261)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
	at net.runelite.client.callback.Hooks.post(Hooks.java:194)
	at client.cl(client.java:59515)
	at jg.hl(jg.java:1342)
	at as.hy(ak.java:2876)
	at ef.hz(ef.java:2880)
	at client.jt(client.java:55598)
	at client.hm(client.java:3033)
	at client.bj(client.java:1161)
	at bm.an(bm.java:394)
	at bm.ib(bm.java)
	at bm.run(bm.java:52825)
	at java.base/java.lang.Thread.run(Thread.java:832)
```