### PR TITLE
Fix alchemist amulet duplication

### DIFF
--- a/src/main/java/com/evansloan/collectionlog/CollectionLogList.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogList.java
@@ -9,9 +9,9 @@ enum CollectionLogList
 {
 	BOSSES(12),
 	RAIDS(16),
-	CLUES(32),
-	MINIGAMES(35),
-	OTHER(34);
+	CLUES(33),
+	MINIGAMES(36),
+	OTHER(35);
 
 	private final int listIndex;
 }

--- a/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
@@ -43,7 +43,6 @@ public class CollectionLogManager
 		474, // Minigames
 		475  // Other
 	);
-	private static final List<Integer> COLLECTION_LOG_TAB_ENUM_IDS = ImmutableList.of(2103, 2104, 2105, 2106, 2107);
 	private static final int COLLECTION_LOG_TAB_NAME_PARAM_ID = 682;
 	private static final int COLLECTION_LOG_TAB_ENUM_PARAM_ID = 683;
 	private static final int COLLECTION_LOG_PAGE_NAME_PARAM_ID = 689;

--- a/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogManager.java
@@ -5,7 +5,6 @@ import com.evansloan.collectionlog.util.CollectionLogSerializer;
 import com.evansloan.collectionlog.util.JsonUtils;
 import com.evansloan.collectionlog.util.UserSettingsDeserializer;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -60,26 +59,13 @@ public class CollectionLogManager
 	private static final Pattern COLLECTION_LOG_FILE_PATTERN = Pattern.compile("collectionlog-([\\w\\s-]+).json");
 
 	/*
-	 * Map of item IDs that differ in page items struct vs ID on item widget in the collection log
+	 * Enum containing a map of item IDs that differ in page items struct vs ID on item widget in the collection log
 	 * Both IDs are valid, but causes duplicates on site
 	 *
 	 * Key: Page struct item ID
 	 * Value: Item widget item ID
 	 */
-	private static final Map<Integer, Integer> ITEM_ID_MAP = new ImmutableMap.Builder<Integer, Integer>()
-		.put(10859, 25617) // Tea flask
-		.put(10877, 25618) // Red satchel
-		.put(10878, 25619) // Green satchel
-		.put(10879, 25620) // Red satchel
-		.put(10880, 25621) // Black satchel
-		.put(10881, 25622) // Gold satchel
-		.put(10882, 25623) // Rune satchel
-		.put(13273, 25624) // Unsired
-		.put(12019, 25627) // Coal bag
-		.put(12020, 25628) // Gem bag
-		.put(24882, 25629) // Plank sack
-		.put(12854, 25630) // Flamtaer bag
-		.build();
+	private static final int COLLECTION_LOG_ITEM_ID_MAP_ENUM = 3721;
 
 	private final Map<String, CollectionLog> loadedCollectionLogs = new HashMap<>();
 
@@ -123,6 +109,7 @@ public class CollectionLogManager
 		int totalObtained = 0;
 		int totalItems = 0;
 		Map<String, CollectionLogTab> collectionLogTabs = new HashMap<>();
+		EnumComposition itemIdMapEnum = client.getEnum(COLLECTION_LOG_ITEM_ID_MAP_ENUM);
 
 		for (Integer structId : COLLECTION_LOG_TAB_STRUCT_IDS)
 		{
@@ -153,9 +140,10 @@ public class CollectionLogManager
 					ItemComposition itemComposition = itemManager.getItemComposition(pageItemId);
 					CollectionLogItem item = CollectionLogItem.fromItemComposition(itemComposition, pageItems.size());
 
-					if (ITEM_ID_MAP.containsKey(item.getId()))
+					int mappedId = itemIdMapEnum.getIntValue(item.getId());
+					if (mappedId != -1)
 					{
-						item.setId(ITEM_ID_MAP.get(item.getId()));
+						item.setId(mappedId);
 					}
 
 					if (saveDataExists && saveFilePage != null)

--- a/src/main/java/com/evansloan/collectionlog/CollectionLogPlugin.java
+++ b/src/main/java/com/evansloan/collectionlog/CollectionLogPlugin.java
@@ -1113,7 +1113,7 @@ public class CollectionLogPlugin extends Plugin
 			return null;
 		}
 
-		Widget containerChild = collLogContainer.getStaticChildren()[0];
+		Widget containerChild = collLogContainer.getStaticChildren()[0].getStaticChildren()[0];
 		return containerChild.getDynamicChildren()[1];
 	}
 


### PR DESCRIPTION
The first commit in this PR updates the plugin to use [client Enum 3721](https://abextm.github.io/cache2/#/viewer/enum/3721) to decide what item ids need to be switched, rather than using a hardcoded map. That fixes the alchemist amulet duplication that I mentioned in https://github.com/evansloan/collectionlog.net/pull/116 and that someone else reported in https://github.com/evansloan/collectionlog.net/issues/132. I don't know if you'll need to do something on your end to remove existing duplicates on the site (edit: https://github.com/evansloan/collection-log-api/issues/7?), but this change should hopefully at least prevent new duplicates from coming?

The second commit in this PR removes a list that was defined but unused (at some point, it seems like you switched things to read the values that were in that list from a client struct).

The third commit in this PR updates some widget ids that were preventing the plugin from working properly when I tried to test the first commit (NPEs and IndexOutOfBounds errors). I don't know what caused the issues - maybe it was changes due to the big collection log update from a few weeks ago (in which case, I'm surprised there haven't been bug reports for the plugin), maybe it was because I was testing on a f2p account, or maybe it was something else entirely.

I can drop the second or third commit (or both) from this PR if you'd like - it was really the first commit I wanted to make.